### PR TITLE
udev: do not link to post-install file

### DIFF
--- a/recipes-core/systemd/systemd_225.bbappend
+++ b/recipes-core/systemd/systemd_225.bbappend
@@ -4,8 +4,12 @@
 # LOCAL REV: add WR specific scripts
 #
 
-do_install_append() {
-    ln -sf /dev/null  ${D}${sysconfdir}/udev/rules.d/80-net-setup-link.rules
+pkg_postinst_udev_append() { 
+    if [ x"$D" = "x" ];then
+        ln -sf /dev/null ${sysconfdir}/udev/rules.d/80-net-setup-link.rules
+    else
+        ln -sf /dev/null .${sysconfdir}/udev/rules.d/80-net-setup-link.rules
+    fi
 }
 
 PACKAGECONFIG_append = " networkd"


### PR DESCRIPTION
Issue: LIN8-2326

Linking /dev/null to a post-install file causes dependencies
errors when installing the udev rpm.

The /dev/null -file- does not belong to any rpm but is
rather part of the filesystem image so it should only
be created by using a post-install script.

Signed-off-by: Jian Liu <jian.liu@windriver.com>
Signed-off-by: De Huo <De.Huo@windriver.com>