### PR TITLE
systemd: fix defect about machine id change after system upgrade

### DIFF
--- a/recipes-core/systemd/systemd_225.bbappend
+++ b/recipes-core/systemd/systemd_225.bbappend
@@ -11,3 +11,7 @@ SRC_URI += "\
 "
 
 PACKAGECONFIG_append = " networkd"
+
+pkg_postinst_systemd_append() {
+       systemd-machine-id-setup 2>/dev/null
+}


### PR DESCRIPTION
Issue: LINPUL8-764

Add command 'systemd-machine-id-setup' in rpm postinstall script
to generate machine id after package is installed.

Signed-off-by: De Huo <De.Huo@windriver.com>